### PR TITLE
Eq crash fixes

### DIFF
--- a/boustrophedon_server/include/boustrophedon_server/boustrophedon_planner_server.h
+++ b/boustrophedon_server/include/boustrophedon_server/boustrophedon_planner_server.h
@@ -69,6 +69,7 @@ private:
   tf::TransformListener transform_listener_{};
   bool publish_polygons_{};
   bool publish_path_points_{};
+  bool only_subscribed_parameters_{};
   std::string last_status_{};
 
   bool convertStripingPlanToPath(boustrophedon_msgs::ConvertPlanToPath::Request& request,

--- a/boustrophedon_server/launch/boustrophedon_server.launch
+++ b/boustrophedon_server/launch/boustrophedon_server.launch
@@ -20,10 +20,10 @@
     <arg name="turn_start_offset" default="0.0" />
     <!-- u turn radius works only if enable_bulb_turns is enabled -->
     <arg name="u_turn_radius" default="1.0" />
-    <arg name="publish_polygons" default="true"/>
-    <arg name="publish_path_points" default="true"/>
+    <arg name="publish_polygons" default="false"/>
+    <arg name="publish_path_points" default="false"/>
     <arg name="parameters_topic" default="/user_bplanner_config_update"/>
-    <!-- set below to false if plan should fail until first parameters from topic received -->
+    <!-- set below to true if plan should fail until first parameters from topic received -->
     <arg name="only_subscribed_parameters" default="true" />
 
     <node pkg="boustrophedon_server" type="boustrophedon_planner_server" name="boustrophedon_server" output="screen" respawn="true">

--- a/boustrophedon_server/launch/boustrophedon_server.launch
+++ b/boustrophedon_server/launch/boustrophedon_server.launch
@@ -3,7 +3,7 @@
     <arg name="outline_clockwise" default="true"/>
     <arg name="skip_outlines" default="false"/>
     <arg name="outline_layer_count" default="0"/>
-    <arg name="stripe_separation" default="1.2"/>
+    <arg name="stripe_separation" default="1.0"/>
     <arg name="intermediary_separation" default="0.0"/>
     <arg name="stripe_angle" default="0.0"/>
     <arg name="enable_stripe_angle_orientation" default="false" />
@@ -14,8 +14,8 @@
     <!-- In UI settings just input 1, 2, or 3 under turn_type. 0 to follow boundary normally-->
     <!-- Note: if enabling half-y turns, must have an outline_layer_count >= 1 -->
     <arg name="enable_half_y_turns" default="false" />
-    <arg name="enable_full_u_turns" default="false" />
-    <arg name="enable_bulb_turns" default="true" />
+    <arg name="enable_full_u_turns" default="true" />
+    <arg name="enable_bulb_turns" default="false" />
     <arg name="points_per_turn" default="20" />
     <arg name="turn_start_offset" default="0.0" />
     <!-- u turn radius works only if enable_bulb_turns is enabled -->
@@ -23,6 +23,8 @@
     <arg name="publish_polygons" default="true"/>
     <arg name="publish_path_points" default="true"/>
     <arg name="parameters_topic" default="/user_bplanner_config_update"/>
+    <!-- set below to false if plan should fail until first parameters from topic received -->
+    <arg name="only_subscribed_parameters" default="true" />
 
     <node pkg="boustrophedon_server" type="boustrophedon_planner_server" name="boustrophedon_server" output="screen" respawn="true">
         <param name="repeat_boundary" value="$(arg repeat_boundary)"/>
@@ -45,5 +47,6 @@
         <param name="publish_polygons" value="$(arg publish_polygons)"/>
         <param name="publish_path_points" value="$(arg publish_path_points)"/>
         <param name="parameters_topic" value="$(arg parameters_topic)"/>
+        <param name="only_subscribed_parameters" value="$(arg only_subscribed_parameters)" />
     </node>
 </launch>

--- a/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
@@ -237,11 +237,7 @@ void BoustrophedonPlannerServer::configAndExecutePlanPathAction(const boustrophe
   auto path = executePlanPathInternal(goal, params_);
   auto result = toResult(std::move(path), boundary_frame);
 
-  if (action_server_with_param_.isPreemptRequested())
-  {
-    action_server_with_param_.setPreempted();
-  }
-  else if (last_status_.empty())
+  if (last_status_.empty())
   {
     boustrophedon_msgs::PlanMowingPathParamResult result_with_param;
     result_with_param.plan = result.plan;
@@ -261,13 +257,7 @@ void BoustrophedonPlannerServer::executePlanPathAction(const boustrophedon_msgs:
   auto path = executePlanPathInternal(*goal, params_);
   auto result = toResult(std::move(path), boundary_frame);
   double request_angle = params_.stripe_angle_ * 180.0 / 3.1415927;
-  if (action_server_.isPreemptRequested())
-  {
-    ROS_INFO_STREAM("Preempt requested. Cancelling plan. angle: " << request_angle);
-    last_status_ = "Request cancelled by client. angle: " + std::to_string(request_angle);
-    action_server_.setPreempted(Server::Result(), last_status_);
-  }
-  else if (last_status_.empty())
+  if (last_status_.empty())
   {
     action_server_.setSucceeded(result, std::to_string(request_angle));
     ROS_INFO_STREAM("Success result sent.");

--- a/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
@@ -36,6 +36,10 @@ BoustrophedonPlannerServer::BoustrophedonPlannerServer()
     polygon_points_publisher_ = private_node_handle_.advertise<geometry_msgs::PointStamped>("polygon_points", 1000);
   }
 
+  if (only_subscribed_parameters_)
+  {
+    last_status_ = std::string("Initial parameters not yet received.");
+  }
 }
 
 std::size_t BoustrophedonPlannerServer::fetchParams()
@@ -83,6 +87,8 @@ std::size_t BoustrophedonPlannerServer::fetchParams()
       !rosparam_shortcuts::get("plan_path", private_node_handle_, "stripes_before_outlines", new_params.stripes_before_outlines_));
   error += static_cast<std::size_t>(
       !rosparam_shortcuts::get("plan_path", private_node_handle_, "parameters_topic", parameters_topic_));
+  error += static_cast<std::size_t>(
+      !rosparam_shortcuts::get("plan_path", private_node_handle_, "only_subscribed_parameters", only_subscribed_parameters_));
 
   rosparam_shortcuts::shutdownIfError("plan_path", error);
 
@@ -133,6 +139,8 @@ void BoustrophedonPlannerServer::updateParamsInternal(const boustrophedon_msgs::
       break;
   }
   loadParams(new_params);
+
+  last_status_.clear();
 }
 
 std::size_t BoustrophedonPlannerServer::loadParams(Parameters new_params)
@@ -263,6 +271,10 @@ std::vector<NavPoint> BoustrophedonPlannerServer::executePlanPathInternal(
                                                     Parameters params)
 {
   // std::string boundaexecutePlanPathInternalry_frame = goal->property.header.frame_id;
+  if (std::string("Initial parameters not yet received.") == last_status_)
+  {
+    return {};
+  }
   last_status_.clear();
 
   ROS_INFO_STREAM("using Angle: " << params.stripe_angle_ * 180 / 3.14159265359 << " and Spacing: " << params.stripe_separation_);

--- a/boustrophedon_server/src/boustrophedon_server/cellular_decomposition/polygon_decomposer.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/cellular_decomposition/polygon_decomposer.cpp
@@ -245,6 +245,9 @@ bool PolygonDecomposer::findAbovePoint(Point& above, const Point& critical_point
   }
 
   // the critical point was found, but there might not be a next point in the list
+  if (it == points.end())
+    return false;
+
   auto next = it + 1;
   if (next != points.end())
   {

--- a/boustrophedon_server/src/boustrophedon_server/cgal_utils.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/cgal_utils.cpp
@@ -240,10 +240,19 @@ Polygon mergePolygons(const Polygon& poly_1, const Polygon& poly_2)
         poly_1_ending = poly_1_circulator;
         break;
       }
+
     }
     poly_1_circulator++;
 
   } while (poly_1_circulator != poly_1.vertices_circulator());
+
+  // a weird case where there is only one shared vertex
+  // we can't merge this subpoly if that's the case
+  if (nullptr == poly_1_ending.container())
+  {
+    new_poly = poly_1;
+    return new_poly;
+  }
 
   // add all of the points from poly_1_circulator to poly_1_circulator - 1 , inclusive, to new_poly
   // this gives us all the points in polygon 1, ending on the leading edge of the boundary between the two polygons

--- a/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
@@ -19,6 +19,11 @@ void StripingPlanner::addToPath(const Polygon& polygon, const Polygon& sub_polyg
 
   fillPolygon(sub_polygon, new_path_section, robot_position);
 
+  if (new_path_section.empty())
+  {
+    return;
+  }
+
   if (params_.travel_along_boundary)
   {
     std::vector<NavPoint> start_to_striping =

--- a/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
@@ -709,6 +709,10 @@ bool StripingPlanner::isLeftClosest(const Polygon& polygon, const Point& robot_p
   starting_points.insert(starting_points.end(), right_points.begin(), right_points.end());
   std::sort(starting_points.begin(), starting_points.end(), compare_current_point_distance);
 
+  // if we cannot determine, fix this to false
+  if (starting_points.empty())
+    return false;
+
   // if the closest potential starting point is on the left, return true. If not, return false.
   return starting_points.front().x() == min_x;
 }

--- a/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
@@ -134,7 +134,8 @@ void StripingPlanner::fillPolygon(const Polygon& polygon, std::vector<NavPoint>&
         }
         else
         {
-          auto edge_delta = 2.0 * (params_.stripe_separation + params_.u_turn_radius);
+          auto factor = params_.enable_bulb_turn ? 5.0 : 3.0;
+          auto edge_delta = factor * (params_.stripe_separation + params_.u_turn_radius);
 
           // do not make an arc turn if the difference between the two edge points make the plan go over the safety edge
           // instead revert to following the boundary edge to get to the next point
@@ -229,10 +230,16 @@ bool StripingPlanner::isTurnAreaSufficient(const std::vector<NavPoint>& path, co
   }
 
   double turn_offset{0.0};
+
+  double boundary_angle = atan2(fabs(path.back().point.y() - next_stripe.front().y()), params_.stripe_separation);
+  double setback_factor = 1.2 * (1 - sin(boundary_angle)) / cos(boundary_angle);
   if (params_.enable_bulb_turn)
-    turn_offset = std::max(2.5 * params_.u_turn_radius, 2 * params_.stripe_separation);
+  {
+    turn_offset = std::max(4.6 * params_.u_turn_radius, 2.3 * params_.stripe_separation);
+    // turn_offset += turn_offset * setback_factor;
+  }
   else
-    turn_offset = params_.stripe_separation;
+    turn_offset = params_.stripe_separation * 2.3 + params_.stripe_separation * setback_factor;
 
   bool allowed = false;
   if (definitelyGreaterThan(abs(path.back().point.y() - path[path.size() - 2].point.y()),
@@ -453,9 +460,6 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
   Point turn_start_neighbor;
   Point turn_end_neighbor;
 
-  BSpline arc_entry_curve;
-  BSpline arc_exit_curve;
-
   std::vector<NavPoint> arc;
   std::vector<NavPoint> arc_trace;
   double arc_center_offset;
@@ -475,12 +479,13 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     rad_offset = 0.0;
   }
 
-  arc_entry_curve.set_steps(params_.points_per_turn);
-  arc_exit_curve.set_steps(params_.points_per_turn);
-
   double arc_radius = arc_center_offset + params_.stripe_separation / 2.0;
   double start_rad, start_rad_offset;
   double end_rad, end_rad_offset;
+
+  // for now this edge boundary turning is only guaranteed for non-bulb u-turns
+  double boundary_angle = atan2(fabs(path.back().point.y() - next_stripe_start.y()), params_.stripe_separation);
+  double turn_setback = arc_radius * (1 - sin(boundary_angle)) / cos(boundary_angle);
 
   constexpr double k_lookahead_factor = 2.3;
 
@@ -495,8 +500,8 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     // the arc is centered between the two stripes
     arc_center_point =
           Point((path.back().point.x() + next_stripe_start.x()) / 2.0,
-                (path.back().point.y() + next_stripe_start.y()) / 2.0
-                 + params_.turn_start_offset - arc_radius);
+                std::min(path.back().point.y(), next_stripe_start.y())
+                 + params_.turn_start_offset - turn_setback);
 
     // Common circular arc, starts from PI and ends at 0 (upper semicircle from left to right)
     start_rad = CGAL_PI;
@@ -505,11 +510,11 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     end_rad_offset = 0.0 - rad_offset;
 
     turn_start_point = Point(path.back().point.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset - k_lookahead_factor * arc_radius);
+                             std::min(path.back().point.y(), next_stripe_start.y())
+                             + params_.turn_start_offset - arc_radius * k_lookahead_factor);
     turn_end_point = Point(next_stripe_start.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset - k_lookahead_factor * arc_radius);
+                           std::min(path.back().point.y(), next_stripe_start.y())
+                           + params_.turn_start_offset - arc_radius * k_lookahead_factor);
     turn_start_neighbor = Point(turn_start_point.x(), turn_start_point.y() + 0.1);
     turn_end_neighbor = Point(turn_end_point.x(), turn_end_point.y() - 0.1);
   }
@@ -520,8 +525,8 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     // the arc is centered between the two stripes
     arc_center_point =
           Point((path.back().point.x() + next_stripe_start.x()) / 2.0,
-                (path.back().point.y() + next_stripe_start.y()) / 2.0
-                 - params_.turn_start_offset + arc_radius);
+                std::max(path.back().point.y(), next_stripe_start.y())
+                 - params_.turn_start_offset + turn_setback);
 
     // Common circular arc, starts from CGAL_PI and ends at CGAL_PI * 2 (lower semicircle, left to right)
     start_rad = CGAL_PI;
@@ -530,11 +535,11 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     end_rad_offset = CGAL_PI * 2 + rad_offset;
 
     turn_start_point = Point(path.back().point.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset + k_lookahead_factor * arc_radius);
+                             std::max(path.back().point.y(), next_stripe_start.y())
+                             - params_.turn_start_offset + arc_radius * k_lookahead_factor);
     turn_end_point = Point(next_stripe_start.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset + k_lookahead_factor * arc_radius);
+                           std::max(path.back().point.y(), next_stripe_start.y())
+                           - params_.turn_start_offset + arc_radius * k_lookahead_factor);
     turn_start_neighbor = Point(turn_start_point.x(), turn_start_point.y() - 0.1);
     turn_end_neighbor = Point(turn_end_point.x(), turn_end_point.y() + 0.1);
   }
@@ -545,8 +550,8 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     // the arc is centered between the two stripes
     arc_center_point =
           Point((path.back().point.x() + next_stripe_start.x()) / 2.0,
-                (path.back().point.y() + next_stripe_start.y()) / 2.0
-                 + params_.turn_start_offset - arc_radius);
+                std::min(path.back().point.y(), next_stripe_start.y())
+                 + params_.turn_start_offset - turn_setback);
 
     // Common circular arc, starts from 0 and ends at CGAL_PI (upper semicircle, right to left)
     start_rad = 0.0;
@@ -555,11 +560,11 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     end_rad_offset = CGAL_PI + rad_offset;
 
     turn_start_point = Point(path.back().point.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset - k_lookahead_factor * arc_radius);
+                             std::min(path.back().point.y(), next_stripe_start.y())
+                             + params_.turn_start_offset - arc_radius * k_lookahead_factor);
     turn_end_point = Point(next_stripe_start.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset - k_lookahead_factor * arc_radius);
+                           std::min(path.back().point.y(), next_stripe_start.y())
+                             + params_.turn_start_offset - arc_radius * k_lookahead_factor);
     turn_start_neighbor = Point(turn_start_point.x(), turn_start_point.y() + 0.1);
     turn_end_neighbor = Point(turn_end_point.x(), turn_end_point.y() - 0.1);
   }
@@ -570,8 +575,8 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     // the arc is centered between the two stripes
     arc_center_point =
           Point((path.back().point.x() + next_stripe_start.x()) / 2.0,
-                (path.back().point.y() + next_stripe_start.y()) / 2.0
-                 - params_.turn_start_offset + arc_radius);
+                std::max(path.back().point.y(), next_stripe_start.y())
+                 - params_.turn_start_offset + turn_setback);
 
     // Common circular arc, starts from CGAL_PI * 2 and ends at CGAL_PI (lower semicircle, right to left)
     start_rad = CGAL_PI * 2;
@@ -580,11 +585,11 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
     end_rad_offset = CGAL_PI - rad_offset;
 
     turn_start_point = Point(path.back().point.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset + k_lookahead_factor * arc_radius);
+                             std::max(path.back().point.y(), next_stripe_start.y())
+                             - params_.turn_start_offset + arc_radius * k_lookahead_factor);
     turn_end_point = Point(next_stripe_start.x(),
-                             (path.back().point.y() + next_stripe_start.y()) / 2.0
-                             + params_.turn_start_offset + k_lookahead_factor * arc_radius);
+                           std::max(path.back().point.y(), next_stripe_start.y())
+                           - params_.turn_start_offset + arc_radius * k_lookahead_factor);
     turn_start_neighbor = Point(turn_start_point.x(), turn_start_point.y() - 0.1);
     turn_end_neighbor = Point(turn_end_point.x(), turn_end_point.y() + 0.1);
   }
@@ -600,10 +605,6 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
                                start_rad, end_rad,
                                params_.points_per_turn);
 
-  arc_trace = generateDiscretizedArc(arc_center_point,
-                                     arc_radius,
-                                     start_rad_offset, end_rad_offset,
-                                     10);
   // The first point in the arc terminates the stripe, and the last point starts the next stripe
   // arc.front().type = PointType::StripeEnd;
   // arc.insert(arc.end(), NavPoint{ PointType::StripeStart, arc.back().point });
@@ -613,50 +614,62 @@ void StripingPlanner::addFullUTurnPoints(std::vector<NavPoint>& path, const Poin
   path.erase(path.end());
   path.push_back(NavPoint(PointType::StripeEnd, turn_start_point));
 
+  BSpline arc_entry_curve;
+  BSpline arc_exit_curve;
+  arc_entry_curve.set_steps(params_.points_per_turn);
+  arc_exit_curve.set_steps(params_.points_per_turn);
 
-  // curve smoothen start
-  arc_entry_curve.add_way_point(Vector(turn_start_point.x(), turn_start_point.y()));
-  arc_entry_curve.add_way_point(Vector(turn_start_neighbor.x(), turn_start_neighbor.y()));
-  arc_entry_curve.add_way_point(Vector(arc_trace.front().point.x(), arc_trace.front().point.y()));
-  arc_entry_curve.add_way_point(Vector(arc_trace[1].point.x(), arc_trace[1].point.y()));
+  if (params_.enable_bulb_turn)
+  {
+    arc_trace = generateDiscretizedArc(arc_center_point,
+                                      arc_radius,
+                                      start_rad_offset, end_rad_offset,
+                                      10);
+    // curve smoothen start
+    arc_entry_curve.add_way_point(Vector(turn_start_point.x(), turn_start_point.y()));
+    arc_entry_curve.add_way_point(Vector(turn_start_neighbor.x(), turn_start_neighbor.y()));
+    arc_entry_curve.add_way_point(Vector(arc_trace.front().point.x(), arc_trace.front().point.y()));
+    arc_entry_curve.add_way_point(Vector(arc_trace[1].point.x(), arc_trace[1].point.y()));
 
 #define USE_ORIGINAL_CIRCULAR_ARC 1
 #if USE_ORIGINAL_CIRCULAR_ARC
-  arc_entry_curve.add_way_point(Vector(arc.front().point.x(), arc.front().point.y()));
+    arc_entry_curve.add_way_point(Vector(arc.front().point.x(), arc.front().point.y()));
 #else
-  for (auto const& nav_point : arc_trace)
-  {
-    arc_entry_curve.add_way_point(Vector(nav_point.point.x(), nav_point.point.y()));
-  }
-  arc_entry_curve.add_way_point(Vector(turn_end_point.x(), turn_end_point.y()));
-  arc_entry_curve.add_way_point(Vector(turn_end_neighbor.x(), turn_end_neighbor.y()));
+    for (auto const& nav_point : arc_trace)
+    {
+      arc_entry_curve.add_way_point(Vector(nav_point.point.x(), nav_point.point.y()));
+    }
+    arc_entry_curve.add_way_point(Vector(turn_end_point.x(), turn_end_point.y()));
+    arc_entry_curve.add_way_point(Vector(turn_end_neighbor.x(), turn_end_neighbor.y()));
 #endif
 
-  // insert the arc points onto the end of the path
-  for (auto const &vector_pt : arc_entry_curve.nodes())
-  {
-    path.push_back(NavPoint(PointType::StripeIntermediate, Point(vector_pt.x(), vector_pt.y())));
+    // insert the arc points onto the end of the path
+    for (auto const &vector_pt : arc_entry_curve.nodes())
+    {
+      path.push_back(NavPoint(PointType::StripeIntermediate, Point(vector_pt.x(), vector_pt.y())));
+    }
   }
 
 #if USE_ORIGINAL_CIRCULAR_ARC
   // circular turn arc
   path.insert(path.end(), arc.begin(), arc.end());
 
-  // curve smoothen end
-  arc_exit_curve.add_way_point(Vector(arc.back().point.x(), arc.back().point.y()));
-  arc_exit_curve.add_way_point(Vector(arc_trace[arc_trace.size()-2].point.x(), arc_trace[arc_trace.size()-2].point.y()));
-  arc_exit_curve.add_way_point(Vector(arc_trace.back().point.x(), arc_trace.back().point.y()));
-  arc_exit_curve.add_way_point(Vector(turn_end_point.x(), turn_end_point.y()));
-  arc_exit_curve.add_way_point(Vector(turn_end_neighbor.x(), turn_end_neighbor.y()));
-  for (auto const &vector_pt : arc_exit_curve.nodes())
+  if (params_.enable_bulb_turn)
   {
-    path.push_back(NavPoint(PointType::StripeIntermediate, Point(vector_pt.x(), vector_pt.y())));
+    // curve smoothen end
+    arc_exit_curve.add_way_point(Vector(arc.back().point.x(), arc.back().point.y()));
+    arc_exit_curve.add_way_point(Vector(arc_trace[arc_trace.size()-2].point.x(), arc_trace[arc_trace.size()-2].point.y()));
+    arc_exit_curve.add_way_point(Vector(arc_trace.back().point.x(), arc_trace.back().point.y()));
+    arc_exit_curve.add_way_point(Vector(turn_end_point.x(), turn_end_point.y()));
+    arc_exit_curve.add_way_point(Vector(turn_end_neighbor.x(), turn_end_neighbor.y()));
+    for (auto const &vector_pt : arc_exit_curve.nodes())
+    {
+      path.push_back(NavPoint(PointType::StripeIntermediate, Point(vector_pt.x(), vector_pt.y())));
+    }
   }
 #endif
 
   path.push_back(NavPoint(PointType::StripeStart, turn_end_neighbor));
-
-
 }
 
 std::vector<NavPoint> StripingPlanner::generateDiscretizedArc(const Point& center_point, const float& radius,


### PR DESCRIPTION
## Description

Various crash handling fixes and fix some existing functionality in b-planner (used in map loading):
- add action that bundles params during execution
- suppress plan execution without an initial param sync
- fixes in u-turn points planning
- fix crashes when loading some angles or plans

Resolves: (links to Github and/or Jira issues this resolves)
GRAZE-793 (please see subtasks for specific optimizations done)

