### PR TITLE
One sided y turns

### DIFF
--- a/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/boustrophedon_planner_server.cpp
@@ -182,23 +182,6 @@ std::size_t BoustrophedonPlannerServer::loadParams(Parameters new_params)
     new_params.intermediary_separation_ = std::numeric_limits<double>::max();
   }
 
-  if (new_params.enable_half_y_turns_ && new_params.outline_layer_count_ < 1)
-  {
-    if (new_params.allow_points_outside_boundary_)
-    {
-      ROS_WARN_STREAM("Current configuration will result in turns that go outside the boundary, but this has been "
-                      "explicitly enabled");
-    }
-    else
-    {
-      // we can't do half-y-turns safely without an inner boundary layer, as the arc will stick outside of the boundary
-      ROS_ERROR_STREAM("Cannot plan using half-y-turns if the outline_layer_count is less than 1! Boustrophedon "
-                       "planner will not update.");
-      new_params.enable_half_y_turns_ = false;
-      return error;
-    }
-  }
-
   // actual update applied with correct settings
   params_ = new_params;
 
@@ -299,7 +282,7 @@ std::vector<NavPoint> BoustrophedonPlannerServer::executePlanPathInternal(
                                                     const boustrophedon_msgs::PlanMowingPathGoal& goal,
                                                     Parameters params)
 {
-  // std::string boundaexecutePlanPathInternalry_frame = goal->property.header.frame_id;
+  // std::string boundary_frame = goal->property.header.frame_id;
   if (std::string("Initial parameters not yet received.") == last_status_)
   {
     return {};
@@ -384,6 +367,7 @@ std::vector<NavPoint> BoustrophedonPlannerServer::executePlanPathInternal(
     // add the stripes to the path, using merged_polygon boundary to travel if necessary.
     striping_planner_.addToPath(merged_polygon, subpoly, robot_position, path);
   }
+
   if (params.travel_along_boundary_)
   {
     striping_planner_.addReturnToStart(merged_polygon, start_position, robot_position, path);

--- a/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
+++ b/boustrophedon_server/src/boustrophedon_server/striping_planner.cpp
@@ -57,6 +57,7 @@ void StripingPlanner::fillPolygon(const Polygon& polygon, std::vector<NavPoint>&
   StripingDirection stripe_dir = StripingDirection::STARTING;
 
   bool left_closest = isLeftClosest(polygon, robot_position, min_x, max_x);
+
   for (auto stripe_num = 0; stripe_num < stripe_count; stripe_num++)
   {
     double x;
@@ -700,8 +701,8 @@ bool StripingPlanner::isLeftClosest(const Polygon& polygon, const Point& robot_p
 {
   // lambda for determining the first striping direction naively
   auto compare_current_point_distance = [&robot_position](const auto& a, const auto& b) {
-    auto comp = CGAL::compare_distance_to_point(robot_position, a, b);
-    return (comp == CGAL::SMALLER);
+    // EQ: revised to look only for nearer x distance
+    return CGAL::abs(robot_position.x() - a.x()) < CGAL::abs(robot_position.x() - b.x());
   };
 
   std::vector<Point> starting_points = getIntersectionPoints(polygon, Line(Point(min_x, 0.0), Point(min_x, 1.0)));
@@ -711,7 +712,10 @@ bool StripingPlanner::isLeftClosest(const Polygon& polygon, const Point& robot_p
 
   // if we cannot determine, fix this to false
   if (starting_points.empty())
+  {
+    std::cout << "WARNING: START POINT NOT FOUND!" << std::endl;
     return false;
+  }
 
   // if the closest potential starting point is on the left, return true. If not, return false.
   return starting_points.front().x() == min_x;


### PR DESCRIPTION
## Description

Applied the following changes:

- [GRAZE-1190](https://wavemakerlabs.atlassian.net/browse/GRAZE-1190) Make sure half Y turns are strictly on one side
- [GRAZE-1211](https://wavemakerlabs.atlassian.net/browse/GRAZE-1211) Allow half-y-turns be planned without outlining

This will point the boustrophedon_planner to the appropriate commit.

## Verification
Tests to verify:

Set the turn type to 2 (half-y turns), then check the created plan:

- [ ] half y-turn should always start with the zero-point turn.
- [ ] turn should always be within the area boundary.
- [ ] it shouldn't complain anymore about the outlines == 0 or allow_travel_outside_boundaries being disabled.